### PR TITLE
[feat] 감정 조회 및 등록 api 개발

### DIFF
--- a/emopic/build.gradle
+++ b/emopic/build.gradle
@@ -1,8 +1,15 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.14'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'checkstyle'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 checkstyle {
@@ -39,6 +46,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	//gcp storage 의존성 추가
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-storage'
+	// querydsl 추가
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -54,6 +64,30 @@ dependencyManagement {
 	}
 }
 
+
+
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/Emotion.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/Emotion.java
@@ -1,0 +1,31 @@
+package mmm.emopic.app.domain.emotion;
+
+import lombok.*;
+import mmm.emopic.app.base.BaseEntity;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import mmm.emopic.app.domain.photo.Photo;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Emotion{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    /*
+    @OneToMany(mappedBy = "emotion", cascade = CascadeType.PERSIST)
+    private List<UserEmotion> userEmotions = new ArrayList<>();
+    */
+    @Builder
+    Emotion(Long id, String name){
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionController.java
@@ -1,0 +1,32 @@
+package mmm.emopic.app.domain.emotion;
+
+
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.base.Dto.BaseResponse;
+import mmm.emopic.app.domain.emotion.dto.request.EmotionUploadRequest;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionUploadResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+public class EmotionController {
+    private final EmotionService emotionService;
+
+    @GetMapping("/emotions")
+    public ResponseEntity<BaseResponse> getEmotions(){
+        List<Emotion> response = emotionService.findEmotions();
+        return ResponseEntity.ok(new BaseResponse(HttpStatus.OK.value(), "전체 감정 조회 성공",response));
+    }
+
+    @PostMapping("/photos/{photoId}/emotions")
+    public ResponseEntity<BaseResponse> saveEmotionsInPhoto(@Validated @RequestBody EmotionUploadRequest emotionUploadRequest, @PathVariable(name ="photoId") Long photoId){
+        EmotionUploadResponse response = emotionService.saveEmotionsInPhoto(emotionUploadRequest,photoId);
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "감정 저장 성공",response));
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionController.java
@@ -4,6 +4,7 @@ package mmm.emopic.app.domain.emotion;
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.base.Dto.BaseResponse;
 import mmm.emopic.app.domain.emotion.dto.request.EmotionUploadRequest;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
 import mmm.emopic.app.domain.emotion.dto.response.EmotionUploadResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class EmotionController {
 
     @GetMapping("/emotions")
     public ResponseEntity<BaseResponse> getEmotions(){
-        List<Emotion> response = emotionService.findEmotions();
+        List<EmotionResponse> response = emotionService.findEmotions();
         return ResponseEntity.ok(new BaseResponse(HttpStatus.OK.value(), "전체 감정 조회 성공",response));
     }
 

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionRepository.java
@@ -1,0 +1,9 @@
+package mmm.emopic.app.domain.emotion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EmotionRepository extends JpaRepository<Emotion,Long> {
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionService.java
@@ -2,6 +2,7 @@ package mmm.emopic.app.domain.emotion;
 
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.domain.emotion.dto.request.EmotionUploadRequest;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
 import mmm.emopic.app.domain.emotion.dto.response.EmotionUploadResponse;
 import mmm.emopic.app.domain.photo.Photo;
 import mmm.emopic.app.domain.photo.PhotoRepository;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,8 +22,9 @@ public class EmotionService {
     private final PhotoRepository photoRepository;
     private final PhotoEmotionRepository photoEmotionRepository;
 
-    public List<Emotion> findEmotions(){
-        return emotionRepository.findAll();
+    public List<EmotionResponse> findEmotions(){
+        return emotionRepository.findAll().stream().map(EmotionResponse::new).collect(Collectors.toList());
+
     }
 
     @Transactional

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionService.java
@@ -1,0 +1,45 @@
+package mmm.emopic.app.domain.emotion;
+
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.emotion.dto.request.EmotionUploadRequest;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionUploadResponse;
+import mmm.emopic.app.domain.photo.Photo;
+import mmm.emopic.app.domain.photo.PhotoRepository;
+import mmm.emopic.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EmotionService {
+    private final EmotionRepository emotionRepository;
+    private final PhotoRepository photoRepository;
+    private final PhotoEmotionRepository photoEmotionRepository;
+
+    public List<Emotion> findEmotions(){
+        return emotionRepository.findAll();
+    }
+
+    @Transactional
+    public EmotionUploadResponse saveEmotionsInPhoto(EmotionUploadRequest emotionUploadRequest, Long photoId){
+        List<Long> emotionIdList = new ArrayList<>();
+        emotionIdList.add(emotionUploadRequest.getEmotionId());
+        emotionIdList.addAll(emotionUploadRequest.getChildEmotions());
+
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+
+        List<Long> photoEmotionIds = new ArrayList<>();
+        for(Long eid: emotionIdList) {
+            Emotion emotion = emotionRepository.findById(eid).orElseThrow(() -> new ResourceNotFoundException("emotion", eid));
+            PhotoEmotion photoEmotion = emotionUploadRequest.toEntity(photo,emotion);
+            PhotoEmotion savedPhotoEmotion = photoEmotionRepository.save(photoEmotion);
+            photoEmotionIds.add(photoEmotion.getId());
+        }
+
+        return new EmotionUploadResponse(photoEmotionIds);
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/PhotoEmotion.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/PhotoEmotion.java
@@ -1,0 +1,35 @@
+package mmm.emopic.app.domain.emotion;
+
+import javax.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mmm.emopic.app.base.BaseEntity;
+import mmm.emopic.app.domain.photo.Photo;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhotoEmotion extends BaseEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emotion_id")
+    private Emotion emotion;
+
+    @Builder
+    public PhotoEmotion(Long id, Photo photo, Emotion emotion) {
+        this.id = id;
+        this.photo = photo;
+        this.emotion = emotion;
+    }
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/PhotoEmotionRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/PhotoEmotionRepository.java
@@ -1,0 +1,6 @@
+package mmm.emopic.app.domain.emotion;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoEmotionRepository extends JpaRepository<PhotoEmotion,Long> {
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/request/EmotionUploadRequest.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/request/EmotionUploadRequest.java
@@ -1,0 +1,28 @@
+package mmm.emopic.app.domain.emotion.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mmm.emopic.app.domain.emotion.Emotion;
+import mmm.emopic.app.domain.emotion.PhotoEmotion;
+import mmm.emopic.app.domain.photo.Photo;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class EmotionUploadRequest {
+
+
+    @NotNull
+    private Long emotionId;
+
+    private List<Long> childEmotions;
+
+    public PhotoEmotion toEntity(Photo photo, Emotion emotion) {
+        return PhotoEmotion.builder()
+                .photo(photo)
+                .emotion(emotion)
+                .build();
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionGetAllResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionGetAllResponse.java
@@ -1,0 +1,7 @@
+package mmm.emopic.app.domain.emotion.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class EmotionGetAllResponse {
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionResponse.java
@@ -1,0 +1,15 @@
+package mmm.emopic.app.domain.emotion.dto.response;
+
+import lombok.Getter;
+import mmm.emopic.app.domain.emotion.Emotion;
+
+@Getter
+public class EmotionResponse {
+    private Long id;
+    private String name;
+
+    public EmotionResponse(Emotion emotion){
+        this.id = emotion.getId();
+        this.name = emotion.getName();
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionUploadResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionUploadResponse.java
@@ -1,0 +1,14 @@
+package mmm.emopic.app.domain.emotion.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class EmotionUploadResponse {
+    private final List<Long> photoEmotionIds;
+
+    public EmotionUploadResponse(List<Long> photoEmotionIds) {
+        this.photoEmotionIds = photoEmotionIds;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoController.java
@@ -2,8 +2,10 @@ package mmm.emopic.app.domain.photo;
 
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.base.Dto.BaseResponse;
-import mmm.emopic.app.domain.photo.dto.PhotoUploadRequest;
-import mmm.emopic.app.domain.photo.dto.PhotoUploadResponse;
+import mmm.emopic.app.domain.photo.dto.request.PhotoCaptionRequest;
+import mmm.emopic.app.domain.photo.dto.response.PhotoCaptionResponse;
+import mmm.emopic.app.domain.photo.dto.request.PhotoUploadRequest;
+import mmm.emopic.app.domain.photo.dto.response.PhotoUploadResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +25,12 @@ public class PhotoController {
     public ResponseEntity createPhoto(@Validated @RequestBody PhotoUploadRequest photoUploadRequest){
         PhotoUploadResponse response = photoService.createPhoto(photoUploadRequest);
         return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "이미지 업로드 signed_url 생성 성공",response));
+    }
+
+    @PostMapping("/photos/caption")
+    public ResponseEntity getPhotoCaption(@Validated @RequestBody PhotoCaptionRequest photoCaptionRequest){
+        PhotoCaptionResponse response = photoService.getPhotoCaption(photoCaptionRequest.getPhotoId());
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "캡셔닝 생성 완료", response));
     }
 
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
@@ -2,9 +2,11 @@ package mmm.emopic.app.domain.photo;
 
 
 import lombok.RequiredArgsConstructor;
-import mmm.emopic.app.domain.photo.dto.PhotoUploadRequest;
-import mmm.emopic.app.domain.photo.dto.PhotoUploadResponse;
+import mmm.emopic.app.domain.photo.dto.response.PhotoCaptionResponse;
+import mmm.emopic.app.domain.photo.dto.request.PhotoUploadRequest;
+import mmm.emopic.app.domain.photo.dto.response.PhotoUploadResponse;
 import mmm.emopic.app.domain.photo.support.SignedURLGenerator;
+import mmm.emopic.exception.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,5 +30,12 @@ public class PhotoService {
             throw new RuntimeException(e);
         }
         return new PhotoUploadResponse(savedPhoto.getId(),signedUrl);
+    }
+
+    @Transactional
+    public PhotoCaptionResponse getPhotoCaption(Long photoId){
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+        return new PhotoCaptionResponse(photo.getCaption());
+
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/request/PhotoCaptionRequest.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/request/PhotoCaptionRequest.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.photo.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PhotoCaptionRequest {
+    private Long photoId;
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoCaptionResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoCaptionResponse.java
@@ -1,0 +1,12 @@
+package mmm.emopic.app.domain.photo.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class PhotoCaptionResponse {
+    private String caption;
+
+    public PhotoCaptionResponse(String caption){
+        this.caption = caption;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/config/QuerydslConfig.java
+++ b/emopic/src/main/java/mmm/emopic/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package mmm.emopic.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/exception/BadRequestException.java
+++ b/emopic/src/main/java/mmm/emopic/exception/BadRequestException.java
@@ -1,0 +1,20 @@
+package mmm.emopic.exception;
+
+public class BadRequestException extends RuntimeException{
+    private String errorCode = "BAD_REQUEST";
+    private String clientMessage = "요청 값이 잘못되었습니다.";
+
+    public BadRequestException(final String serverMessage, final String clientMessage, final String errorCode) {
+        super(serverMessage);
+        this.clientMessage = clientMessage;
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getClientMessage() {
+        return clientMessage;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/exception/ResourceNotFoundException.java
+++ b/emopic/src/main/java/mmm/emopic/exception/ResourceNotFoundException.java
@@ -1,0 +1,22 @@
+package mmm.emopic.exception;
+
+public class ResourceNotFoundException extends BadRequestException {
+    private static final String ERROR_CODE = "BAD_REQUEST";
+    private static final String SERVER_MESSAGE = "존재하지 않는 객체 조회";
+
+    public ResourceNotFoundException(String domain, final Long id) {
+        super(String.format("%s %s id : %d", domain, SERVER_MESSAGE, id), String.format("%s %s id : %d", domain, SERVER_MESSAGE, id), ERROR_CODE);
+    }
+
+    public ResourceNotFoundException(String domain, final Long id1, final Long id2, final Long id3) {
+        super(String.format("%s %s id : %d, %d, %d", domain, SERVER_MESSAGE, id1, id2, id3), String.format("%s %s id : %d %d %d", domain, SERVER_MESSAGE, id1, id2, id3), ERROR_CODE);
+    }
+
+    public ResourceNotFoundException(String domain, final String code) {
+        super(String.format("%s %s code : %s", domain, SERVER_MESSAGE, code), String.format("%s %s url : %s", domain, SERVER_MESSAGE, code), ERROR_CODE);
+    }
+
+    public ResourceNotFoundException(String reason) {
+        super(SERVER_MESSAGE, reason, ERROR_CODE);
+    }
+}

--- a/emopic/src/main/resources/application.yml
+++ b/emopic/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: ${MYSQL_URL}
     username: root
-    password:
+    password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약
<!-- 무엇을 구현하였는지 요약해주세요. -->
 감정 조회 및 등록 기능 개발
# 작업 내용
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->
-  QueryDsl 을 사용하기 위해 설정 파일 작성
-  객체가 존재하지 않는 경우 등 error detecting을 위한 exception format 작성
-  감정 조회 및 등록 기능 개발, 조회의 경우 Emotion* 클래스들에 의해 관리되며, 등록의 경우 PhotoEmotion* 들을 사용.

# 기타 (논의하고 싶은 부분)

close #7 
