### PR TITLE
[feat] Category별 분류 결과 조회 API 개발

### DIFF
--- a/emopic/src/main/java/mmm/emopic/app/domain/category/Category.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/Category.java
@@ -1,0 +1,34 @@
+package mmm.emopic.app.domain.category;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mmm.emopic.app.base.BaseEntity;
+import mmm.emopic.app.domain.photo.Photo;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String thumbnail;
+
+    /*
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+    */
+    @Builder
+    public Category(String name, String thumbnail){
+        this.name = name;
+        this.thumbnail = thumbnail;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryController.java
@@ -1,0 +1,34 @@
+package mmm.emopic.app.domain.category;
+
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.base.Dto.BaseResponse;
+import mmm.emopic.app.domain.category.dto.response.CategoryDetailResponse;
+import mmm.emopic.app.domain.category.dto.request.CategoryRequest;
+import mmm.emopic.app.domain.category.dto.response.CategoryResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+    @PostMapping("/photos/categories")
+    public ResponseEntity<BaseResponse> requestCategories(@Validated @RequestBody CategoryRequest categoryGetAllRequest){
+
+        CategoryResponse response = categoryService.requestCategories(categoryGetAllRequest.getPhotoId());
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "분류 결과 조회 완료", response));
+    }
+
+    @GetMapping("/photos/categories")
+    public ResponseEntity<BaseResponse>  getCategoriesAsMuchAsSize(@RequestParam Long size){
+        CategoryDetailResponse categories = categoryService.getCategoriesAsMuchAsSize(size);
+
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "분류 결과 전체 조회 완료", categories));
+    }
+
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryService.java
@@ -1,0 +1,82 @@
+package mmm.emopic.app.domain.category;
+
+import com.querydsl.core.Tuple;
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.category.dto.response.CategoryDetailResponse;
+import mmm.emopic.app.domain.category.dto.response.CategoryResponse;
+import mmm.emopic.app.domain.category.repository.CategoryRepository;
+import mmm.emopic.app.domain.category.repository.CategoryRepositoryCustom;
+import mmm.emopic.app.domain.category.repository.PhotoCategoryRepository;
+import mmm.emopic.app.domain.photo.Photo;
+import mmm.emopic.app.domain.photo.repository.PhotoRepository;
+import mmm.emopic.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static mmm.emopic.app.domain.category.QPhotoCategory.photoCategory;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final CategoryRepositoryCustom categoryRepositoryCustom;
+    private final PhotoRepository photoRepository;
+    private final PhotoCategoryRepository photoCategoryRepository;
+    @Transactional
+    public Category createCategory(String name){
+        Category category = Category.builder().name(name).build();
+        return categoryRepository.save(category);
+    }
+
+    @Transactional
+    public void saveCategoriesInPhoto(Long photoId, List<Long> categoryIdList){
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+        for(Long cid : categoryIdList){
+            Category category = categoryRepository.findById(cid).orElseThrow(() -> new ResourceNotFoundException("category", cid));
+            PhotoCategory photoCategory = PhotoCategory.builder().photo(photo).category(category).build();
+            PhotoCategory savedPhotoCategory = photoCategoryRepository.save(photoCategory);
+        }
+    }
+    @Transactional
+    public CategoryResponse requestCategories(Long photoId){
+        /**
+         * getClassificationsByPhoto()함수
+         * photoId에 해당하는 photo의 classification 결과를 AI inference 서버에 받아오기
+         * List<String> 형태로 받아옴
+         *
+         */
+        // 임시 리스트
+        List<String> result = new ArrayList<>();
+        //result.add("고양이");
+        //result.add("탁자");
+        //result.add("계산기");
+        //
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+        for(String categoryName : result){
+            Category category = categoryRepository.findByName(categoryName).orElseGet(() -> createCategory(categoryName)
+            );
+            PhotoCategory photoCategory = PhotoCategory.builder().photo(photo).category(category).build();
+            PhotoCategory savedPhotoCategory = photoCategoryRepository.save(photoCategory);
+        }
+
+        return new CategoryResponse(result);
+    }
+
+    @Transactional
+    public CategoryDetailResponse getCategoriesAsMuchAsSize(Long size) {
+        CategoryDetailResponse result = new CategoryDetailResponse();
+        List<Tuple> list = categoryRepositoryCustom.getMostCategory(size);
+        for (Tuple tuple : list) {
+            System.out.println(tuple);
+            Long categoryId = tuple.get(photoCategory.category.id);
+            Long count = tuple.get(photoCategory.category.id.count());
+            Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new ResourceNotFoundException("category", categoryId));
+            result.AddCategoryDetail(category,count);
+        }
+        return result;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/PhotoCategory.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/PhotoCategory.java
@@ -1,0 +1,35 @@
+package mmm.emopic.app.domain.category;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mmm.emopic.app.base.BaseEntity;
+import mmm.emopic.app.domain.emotion.Emotion;
+import mmm.emopic.app.domain.photo.Photo;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhotoCategory extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    public PhotoCategory(Long id, Photo photo, Category category){
+        this.id = id;
+        this.photo = photo;
+        this.category = category;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/request/CategoryRequest.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/request/CategoryRequest.java
@@ -1,0 +1,14 @@
+package mmm.emopic.app.domain.category.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class CategoryRequest {
+    @NotNull
+    private Long photoId;
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryDetailResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryDetailResponse.java
@@ -1,0 +1,32 @@
+package mmm.emopic.app.domain.category.dto.response;
+
+import lombok.Getter;
+import mmm.emopic.app.domain.category.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CategoryDetailResponse {
+
+    private  final List<CategoryDetail> categories = new ArrayList<>();
+    @Getter
+    public static class CategoryDetail{
+        private final Long categoryId;
+        private final String name;
+        private final Long count;
+        private final String thumbnail;
+        public CategoryDetail(Category category, Long count){
+            this.categoryId = category.getId();
+            this.name = category.getName();
+            this.thumbnail = category.getThumbnail();
+            this.count = count;
+        }
+
+    }
+
+
+    public void AddCategoryDetail(Category category, Long count){
+        categories.add(new CategoryDetail(category,count));
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryResponse.java
@@ -1,0 +1,15 @@
+package mmm.emopic.app.domain.category.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CategoryResponse {
+
+    private final List<String> categories;
+
+    public CategoryResponse(List<String> categories){
+        this.categories = categories;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.category.repository;
+
+import mmm.emopic.app.domain.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryCustom.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.category.repository;
+
+import com.querydsl.core.Tuple;
+
+import java.util.List;
+
+public interface CategoryRepositoryCustom {
+
+    List<Tuple> getMostCategory(Long size);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryImpl.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package mmm.emopic.app.domain.category.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.category.repository.CategoryRepositoryCustom;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static mmm.emopic.app.domain.category.QPhotoCategory.photoCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryRepositoryImpl implements CategoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<Tuple> getMostCategory(Long size) {
+        List<Tuple> queryResults = queryFactory
+                .select(photoCategory.category.id, photoCategory.category.id.count())
+                .from(photoCategory)
+                .groupBy(photoCategory.category.id)
+                .orderBy(photoCategory.category.id.count().desc())
+                .limit(size)
+                .fetch();
+        return queryResults;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/PhotoCategoryRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/PhotoCategoryRepository.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.category.repository;
+
+import mmm.emopic.app.domain.category.PhotoCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PhotoCategoryRepository extends JpaRepository<PhotoCategory, Long> {
+    List<PhotoCategory> findByPhoto_Id(Long photoId);
+}


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약
<!-- 무엇을 구현하였는지 요약해주세요. -->
 Category별 분류 결과 조회 기능을 전체, 세부로 나누어 개발.
# 작업 내용
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->
-  Category Entity및 추가.
-  Controller 및 Service, Repository에 이미지 의 분류결과를 조회하는 기능과 사용자의 모든 이미지 분류 결과를 조회하는 기능 추가
-  Category와 Photo의 관계를 설정 하기 위해 PhotoCategory Entity 추가

# 기타 (논의하고 싶은 부분)

close 
