### PR TITLE
[feat] 개별사진조회 및 분류결과세부조회 기능 개발

### DIFF
--- a/emopic/src/main/java/mmm/emopic/app/domain/category/Category.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/Category.java
@@ -1,0 +1,34 @@
+package mmm.emopic.app.domain.category;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mmm.emopic.app.base.BaseEntity;
+import mmm.emopic.app.domain.photo.Photo;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String thumbnail;
+
+    /*
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+    */
+    @Builder
+    public Category(String name, String thumbnail){
+        this.name = name;
+        this.thumbnail = thumbnail;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryController.java
@@ -1,0 +1,34 @@
+package mmm.emopic.app.domain.category;
+
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.base.Dto.BaseResponse;
+import mmm.emopic.app.domain.category.dto.response.CategoryDetailResponse;
+import mmm.emopic.app.domain.category.dto.request.CategoryRequest;
+import mmm.emopic.app.domain.category.dto.response.CategoryResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+    @PostMapping("/photos/categories")
+    public ResponseEntity<BaseResponse> requestCategories(@Validated @RequestBody CategoryRequest categoryGetAllRequest){
+
+        CategoryResponse response = categoryService.requestCategories(categoryGetAllRequest.getPhotoId());
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "분류 결과 조회 완료", response));
+    }
+
+    @GetMapping("/photos/categories")
+    public ResponseEntity<BaseResponse>  getCategoriesAsMuchAsSize(@RequestParam Long size){
+        CategoryDetailResponse categories = categoryService.getCategoriesAsMuchAsSize(size);
+
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "분류 결과 전체 조회 완료", categories));
+    }
+
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryService.java
@@ -1,0 +1,82 @@
+package mmm.emopic.app.domain.category;
+
+import com.querydsl.core.Tuple;
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.category.dto.response.CategoryDetailResponse;
+import mmm.emopic.app.domain.category.dto.response.CategoryResponse;
+import mmm.emopic.app.domain.category.repository.CategoryRepository;
+import mmm.emopic.app.domain.category.repository.CategoryRepositoryCustom;
+import mmm.emopic.app.domain.category.repository.PhotoCategoryRepository;
+import mmm.emopic.app.domain.photo.Photo;
+import mmm.emopic.app.domain.photo.repository.PhotoRepository;
+import mmm.emopic.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static mmm.emopic.app.domain.category.QPhotoCategory.photoCategory;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final CategoryRepositoryCustom categoryRepositoryCustom;
+    private final PhotoRepository photoRepository;
+    private final PhotoCategoryRepository photoCategoryRepository;
+    @Transactional
+    public Category createCategory(String name){
+        Category category = Category.builder().name(name).build();
+        return categoryRepository.save(category);
+    }
+
+    @Transactional
+    public void saveCategoriesInPhoto(Long photoId, List<Long> categoryIdList){
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+        for(Long cid : categoryIdList){
+            Category category = categoryRepository.findById(cid).orElseThrow(() -> new ResourceNotFoundException("category", cid));
+            PhotoCategory photoCategory = PhotoCategory.builder().photo(photo).category(category).build();
+            PhotoCategory savedPhotoCategory = photoCategoryRepository.save(photoCategory);
+        }
+    }
+    @Transactional
+    public CategoryResponse requestCategories(Long photoId){
+        /**
+         * getClassificationsByPhoto()함수
+         * photoId에 해당하는 photo의 classification 결과를 AI inference 서버에 받아오기
+         * List<String> 형태로 받아옴
+         *
+         */
+        // 임시 리스트
+        List<String> result = new ArrayList<>();
+        //result.add("고양이");
+        //result.add("탁자");
+        //result.add("계산기");
+        //
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+        for(String categoryName : result){
+            Category category = categoryRepository.findByName(categoryName).orElseGet(() -> createCategory(categoryName)
+            );
+            PhotoCategory photoCategory = PhotoCategory.builder().photo(photo).category(category).build();
+            PhotoCategory savedPhotoCategory = photoCategoryRepository.save(photoCategory);
+        }
+
+        return new CategoryResponse(result);
+    }
+
+    @Transactional
+    public CategoryDetailResponse getCategoriesAsMuchAsSize(Long size) {
+        CategoryDetailResponse result = new CategoryDetailResponse();
+        List<Tuple> list = categoryRepositoryCustom.getMostCategory(size);
+        for (Tuple tuple : list) {
+            System.out.println(tuple);
+            Long categoryId = tuple.get(photoCategory.category.id);
+            Long count = tuple.get(photoCategory.category.id.count());
+            Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new ResourceNotFoundException("category", categoryId));
+            result.AddCategoryDetail(category,count);
+        }
+        return result;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/PhotoCategory.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/PhotoCategory.java
@@ -1,0 +1,35 @@
+package mmm.emopic.app.domain.category;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mmm.emopic.app.base.BaseEntity;
+import mmm.emopic.app.domain.emotion.Emotion;
+import mmm.emopic.app.domain.photo.Photo;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhotoCategory extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_id")
+    private Photo photo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Builder
+    public PhotoCategory(Long id, Photo photo, Category category){
+        this.id = id;
+        this.photo = photo;
+        this.category = category;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/request/CategoryRequest.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/request/CategoryRequest.java
@@ -1,0 +1,14 @@
+package mmm.emopic.app.domain.category.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class CategoryRequest {
+    @NotNull
+    private Long photoId;
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryDetailResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryDetailResponse.java
@@ -1,0 +1,32 @@
+package mmm.emopic.app.domain.category.dto.response;
+
+import lombok.Getter;
+import mmm.emopic.app.domain.category.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CategoryDetailResponse {
+
+    private  final List<CategoryDetail> categories = new ArrayList<>();
+    @Getter
+    public static class CategoryDetail{
+        private final Long categoryId;
+        private final String name;
+        private final Long count;
+        private final String thumbnail;
+        public CategoryDetail(Category category, Long count){
+            this.categoryId = category.getId();
+            this.name = category.getName();
+            this.thumbnail = category.getThumbnail();
+            this.count = count;
+        }
+
+    }
+
+
+    public void AddCategoryDetail(Category category, Long count){
+        categories.add(new CategoryDetail(category,count));
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryResponse.java
@@ -1,0 +1,15 @@
+package mmm.emopic.app.domain.category.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CategoryResponse {
+
+    private final List<String> categories;
+
+    public CategoryResponse(List<String> categories){
+        this.categories = categories;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.category.repository;
+
+import mmm.emopic.app.domain.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryCustom.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.category.repository;
+
+import com.querydsl.core.Tuple;
+
+import java.util.List;
+
+public interface CategoryRepositoryCustom {
+
+    List<Tuple> getMostCategory(Long size);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryImpl.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/CategoryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package mmm.emopic.app.domain.category.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.category.repository.CategoryRepositoryCustom;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static mmm.emopic.app.domain.category.QPhotoCategory.photoCategory;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryRepositoryImpl implements CategoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<Tuple> getMostCategory(Long size) {
+        List<Tuple> queryResults = queryFactory
+                .select(photoCategory.category.id, photoCategory.category.id.count())
+                .from(photoCategory)
+                .groupBy(photoCategory.category.id)
+                .orderBy(photoCategory.category.id.count().desc())
+                .limit(size)
+                .fetch();
+        return queryResults;
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/repository/PhotoCategoryRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/repository/PhotoCategoryRepository.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.category.repository;
+
+import mmm.emopic.app.domain.category.PhotoCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PhotoCategoryRepository extends JpaRepository<PhotoCategory, Long> {
+    List<PhotoCategory> findByPhoto_Id(Long photoId);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.base.Dto.BaseResponse;
 import mmm.emopic.app.domain.emotion.dto.request.EmotionUploadRequest;
 import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
-import mmm.emopic.app.domain.emotion.dto.response.EmotionUploadResponse;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionRelatedPhotoResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -27,7 +27,7 @@ public class EmotionController {
 
     @PostMapping("/photos/{photoId}/emotions")
     public ResponseEntity<BaseResponse> saveEmotionsInPhoto(@Validated @RequestBody EmotionUploadRequest emotionUploadRequest, @PathVariable(name ="photoId") Long photoId){
-        EmotionUploadResponse response = emotionService.saveEmotionsInPhoto(emotionUploadRequest,photoId);
+        EmotionRelatedPhotoResponse response = emotionService.saveEmotionsInPhoto(emotionUploadRequest,photoId);
         return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "감정 저장 성공",response));
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/EmotionService.java
@@ -3,9 +3,11 @@ package mmm.emopic.app.domain.emotion;
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.domain.emotion.dto.request.EmotionUploadRequest;
 import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
-import mmm.emopic.app.domain.emotion.dto.response.EmotionUploadResponse;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionRelatedPhotoResponse;
+import mmm.emopic.app.domain.emotion.repository.EmotionRepository;
+import mmm.emopic.app.domain.emotion.repository.PhotoEmotionRepository;
 import mmm.emopic.app.domain.photo.Photo;
-import mmm.emopic.app.domain.photo.PhotoRepository;
+import mmm.emopic.app.domain.photo.repository.PhotoRepository;
 import mmm.emopic.exception.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +30,7 @@ public class EmotionService {
     }
 
     @Transactional
-    public EmotionUploadResponse saveEmotionsInPhoto(EmotionUploadRequest emotionUploadRequest, Long photoId){
+    public EmotionRelatedPhotoResponse saveEmotionsInPhoto(EmotionUploadRequest emotionUploadRequest, Long photoId){
         List<Long> emotionIdList = new ArrayList<>();
         emotionIdList.add(emotionUploadRequest.getEmotionId());
         emotionIdList.addAll(emotionUploadRequest.getChildEmotions());
@@ -43,6 +45,6 @@ public class EmotionService {
             photoEmotionIds.add(photoEmotion.getId());
         }
 
-        return new EmotionUploadResponse(photoEmotionIds);
+        return new EmotionRelatedPhotoResponse(photoEmotionIds);
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/PhotoEmotionRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/PhotoEmotionRepository.java
@@ -1,6 +1,0 @@
-package mmm.emopic.app.domain.emotion;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PhotoEmotionRepository extends JpaRepository<PhotoEmotion,Long> {
-}

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionRelatedPhotoResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionRelatedPhotoResponse.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 import java.util.List;
 
 @Getter
-public class EmotionUploadResponse {
+public class EmotionRelatedPhotoResponse {
     private final List<Long> photoEmotionIds;
 
-    public EmotionUploadResponse(List<Long> photoEmotionIds) {
+    public EmotionRelatedPhotoResponse(List<Long> photoEmotionIds) {
         this.photoEmotionIds = photoEmotionIds;
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/dto/response/EmotionResponse.java
@@ -5,11 +5,11 @@ import mmm.emopic.app.domain.emotion.Emotion;
 
 @Getter
 public class EmotionResponse {
-    private Long id;
+    private Long emotionId;
     private String name;
 
     public EmotionResponse(Emotion emotion){
-        this.id = emotion.getId();
+        this.emotionId = emotion.getId();
         this.name = emotion.getName();
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/repository/EmotionRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/repository/EmotionRepository.java
@@ -1,5 +1,6 @@
-package mmm.emopic.app.domain.emotion;
+package mmm.emopic.app.domain.emotion.repository;
 
+import mmm.emopic.app.domain.emotion.Emotion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/emopic/src/main/java/mmm/emopic/app/domain/emotion/repository/PhotoEmotionRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/emotion/repository/PhotoEmotionRepository.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.emotion.repository;
+
+import mmm.emopic.app.domain.emotion.PhotoEmotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PhotoEmotionRepository extends JpaRepository<PhotoEmotion,Long> {
+    List<PhotoEmotion> findByPhoto_id(Long photoId);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/Photo.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/Photo.java
@@ -30,6 +30,8 @@ public class Photo extends BaseEntity {
 
     private Boolean location_YM = false; // 기본적으로는 위치정보 없는 상태
 
+    private String signedUrl;
+
     @Builder
     public Photo(String name, LocalDateTime snapped_at, String caption, Boolean location_YM) {
         this.name = name;

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoController.java
@@ -2,17 +2,19 @@ package mmm.emopic.app.domain.photo;
 
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.base.Dto.BaseResponse;
+import mmm.emopic.app.domain.photo.dto.response.PhotoInCategoryResponse;
 import mmm.emopic.app.domain.photo.dto.request.PhotoCaptionRequest;
 import mmm.emopic.app.domain.photo.dto.response.PhotoCaptionResponse;
 import mmm.emopic.app.domain.photo.dto.request.PhotoUploadRequest;
+import mmm.emopic.app.domain.photo.dto.response.PhotoInformationResponse;
 import mmm.emopic.app.domain.photo.dto.response.PhotoUploadResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,15 +24,26 @@ public class PhotoController {
 
     //이미지 업로드
     @PostMapping("/photos")
-    public ResponseEntity createPhoto(@Validated @RequestBody PhotoUploadRequest photoUploadRequest){
+    public ResponseEntity<BaseResponse> createPhoto(@Validated @RequestBody PhotoUploadRequest photoUploadRequest){
         PhotoUploadResponse response = photoService.createPhoto(photoUploadRequest);
         return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "이미지 업로드 signed_url 생성 성공",response));
     }
 
     @PostMapping("/photos/caption")
-    public ResponseEntity getPhotoCaption(@Validated @RequestBody PhotoCaptionRequest photoCaptionRequest){
+    public ResponseEntity<BaseResponse> getPhotoCaption(@Validated @RequestBody PhotoCaptionRequest photoCaptionRequest){
         PhotoCaptionResponse response = photoService.getPhotoCaption(photoCaptionRequest.getPhotoId());
         return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "캡셔닝 생성 완료", response));
     }
 
+    @GetMapping("/photos/{photoId}")
+    public ResponseEntity<BaseResponse> getPhotoInformation(@PathVariable(name="photoId") Long photoId){
+        PhotoInformationResponse response = photoService.getPhotoInformation(photoId);
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "개별 사진 조회 완료", response));
+    }
+
+    @GetMapping("/photos/categories/{categoryId}")
+    public ResponseEntity<BaseResponse> getPhotoInCategory(@PathVariable(name = "categoryId") Long categoryId,@PageableDefault(size = 1) Pageable pageable){
+        Page<PhotoInCategoryResponse> response = photoService.getPhotoInCategory(categoryId, pageable);
+        return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "분류 결과 세부 조회 완료", response));
+    }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
@@ -2,15 +2,34 @@ package mmm.emopic.app.domain.photo;
 
 
 import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.category.Category;
+import mmm.emopic.app.domain.category.repository.CategoryRepository;
+import mmm.emopic.app.domain.category.PhotoCategory;
+import mmm.emopic.app.domain.category.repository.PhotoCategoryRepository;
+import mmm.emopic.app.domain.diary.Diary;
+import mmm.emopic.app.domain.diary.repository.DiaryRepository;
+import mmm.emopic.app.domain.emotion.Emotion;
+import mmm.emopic.app.domain.emotion.repository.EmotionRepository;
+import mmm.emopic.app.domain.emotion.PhotoEmotion;
+import mmm.emopic.app.domain.emotion.repository.PhotoEmotionRepository;
 import mmm.emopic.app.domain.photo.dto.response.PhotoCaptionResponse;
 import mmm.emopic.app.domain.photo.dto.request.PhotoUploadRequest;
+import mmm.emopic.app.domain.photo.dto.response.PhotoInCategoryResponse;
+import mmm.emopic.app.domain.photo.dto.response.PhotoInformationResponse;
 import mmm.emopic.app.domain.photo.dto.response.PhotoUploadResponse;
+import mmm.emopic.app.domain.photo.repository.PhotoRepository;
+import mmm.emopic.app.domain.photo.repository.PhotoRepositoryCustom;
 import mmm.emopic.app.domain.photo.support.SignedURLGenerator;
 import mmm.emopic.exception.ResourceNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +37,12 @@ import java.io.IOException;
 public class PhotoService {
     private final PhotoRepository photoRepository;
     private final SignedURLGenerator signedURLGenerator;
+    private final DiaryRepository diaryRepository;
+    private final PhotoCategoryRepository photoCategoryRepository;
+    private final PhotoEmotionRepository photoEmotionRepository;
+    private final CategoryRepository categoryRepository;
+    private final EmotionRepository emotionRepository;
+    private final PhotoRepositoryCustom photoRepositoryCustom;
 
     @Transactional
     public PhotoUploadResponse createPhoto(PhotoUploadRequest photoUploadRequest) {
@@ -34,8 +59,45 @@ public class PhotoService {
 
     @Transactional
     public PhotoCaptionResponse getPhotoCaption(Long photoId){
+        // 캡셔닝 내용을 AI inference서버에서 받아와야 사용 가능
         Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
         return new PhotoCaptionResponse(photo.getCaption());
 
+    }
+
+    @Transactional
+    public PhotoInformationResponse getPhotoInformation(Long photoId) {
+        Photo photo = photoRepository.findById(photoId).orElseThrow(() -> new ResourceNotFoundException("photo", photoId));
+        Diary diary = diaryRepository.findByPhoto_Id(photoId);
+        List<PhotoCategory> photoCategoryList= photoCategoryRepository.findByPhoto_Id(photoId);
+        List<Category> categories = new ArrayList<>();
+        for(PhotoCategory photoCategory : photoCategoryList){
+            Long cid = photoCategory.getCategory().getId();
+            categories.add(categoryRepository.findById(cid).orElseThrow(() -> new ResourceNotFoundException("category",cid )));
+        }
+        List<PhotoEmotion> photoEmotionList = photoEmotionRepository.findByPhoto_id(photoId);
+        List<Emotion> emotions = new ArrayList<>();
+        for(PhotoEmotion photoEmotion : photoEmotionList){
+            Long eid = photoEmotion.getEmotion().getId();
+            emotions.add(emotionRepository.findById(eid).orElseThrow(() -> new ResourceNotFoundException("emotion",eid )));
+        }
+        return new PhotoInformationResponse(photo, diary, categories, emotions);
+    }
+
+    @Transactional
+    public Page<PhotoInCategoryResponse> getPhotoInCategory(Long categoryId, Pageable pageable){
+        Page<Photo> photoList = photoRepositoryCustom.findByCategoryId(categoryId, pageable);
+        List<PhotoInCategoryResponse> results = new ArrayList<>();
+        for(Photo photo : photoList){
+            List<PhotoEmotion> photoEmotionList = photoEmotionRepository.findByPhoto_id(photo.getId());
+            List<Emotion> emotions = new ArrayList<>();
+            for(PhotoEmotion photoEmotion : photoEmotionList){
+                Long eid = photoEmotion.getEmotion().getId();
+                emotions.add(emotionRepository.findById(eid).orElseThrow(() -> new ResourceNotFoundException("emotion",eid )));
+            }
+            results.add(new PhotoInCategoryResponse(photo, emotions));
+        }
+
+        return new PageImpl<>(results,pageable, photoList.getTotalElements());
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/request/PhotoUploadRequest.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/request/PhotoUploadRequest.java
@@ -1,4 +1,4 @@
-package mmm.emopic.app.domain.photo.dto;
+package mmm.emopic.app.domain.photo.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInCategoryResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInCategoryResponse.java
@@ -1,0 +1,28 @@
+package mmm.emopic.app.domain.photo.dto.response;
+
+import lombok.Getter;
+import mmm.emopic.app.domain.category.Category;
+import mmm.emopic.app.domain.diary.Diary;
+import mmm.emopic.app.domain.emotion.Emotion;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
+import mmm.emopic.app.domain.photo.Photo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class PhotoInCategoryResponse {
+    private Long photoId;
+
+    private String signedUrl;
+
+    private List<EmotionResponse> emotions;
+
+    public PhotoInCategoryResponse(Photo photo, List<Emotion> emotionList){
+        this.photoId = photo.getId();
+        this.signedUrl = photo.getSignedUrl();
+        this.emotions = emotionList.stream().map(EmotionResponse::new).collect(Collectors.toList());
+
+    }
+
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInformationResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInformationResponse.java
@@ -1,0 +1,40 @@
+package mmm.emopic.app.domain.photo.dto.response;
+
+import lombok.Getter;
+import mmm.emopic.app.domain.category.Category;
+import mmm.emopic.app.domain.category.PhotoCategory;
+import mmm.emopic.app.domain.diary.Diary;
+import mmm.emopic.app.domain.emotion.Emotion;
+import mmm.emopic.app.domain.emotion.PhotoEmotion;
+import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
+import mmm.emopic.app.domain.photo.Photo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class PhotoInformationResponse {
+
+    private Long photoId;
+
+    private String signedUrl;
+
+    private Long diaryId;
+
+    private String diaryContent;
+
+    private List<String> categories;
+
+    private List<EmotionResponse> emotions;
+
+    public PhotoInformationResponse(Photo photo, Diary diary, List<Category> categoryList, List<Emotion> emotionList){
+        this.photoId = photo.getId();
+        this.signedUrl = photo.getSignedUrl();
+        this.diaryId = diary.getId();
+        this.diaryContent = diary.getContent();
+        this.categories = categoryList.stream().map(Category::getName).collect(Collectors.toList());
+        this.emotions = emotionList.stream().map(EmotionResponse::new).collect(Collectors.toList());
+
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoUploadResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoUploadResponse.java
@@ -1,4 +1,4 @@
-package mmm.emopic.app.domain.photo.dto;
+package mmm.emopic.app.domain.photo.dto.response;
 
 import lombok.Getter;
 

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepository.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepository.java
@@ -1,5 +1,6 @@
-package mmm.emopic.app.domain.photo;
+package mmm.emopic.app.domain.photo.repository;
 
+import mmm.emopic.app.domain.photo.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhotoRepository extends JpaRepository<Photo,Long> {

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepositoryCustom.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepositoryCustom.java
@@ -1,0 +1,10 @@
+package mmm.emopic.app.domain.photo.repository;
+
+import mmm.emopic.app.domain.photo.Photo;
+import mmm.emopic.app.domain.photo.dto.response.PhotoInCategoryResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PhotoRepositoryCustom {
+    Page<Photo> findByCategoryId(Long categoryId, Pageable pageable);
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepositoryCustomImpl.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package mmm.emopic.app.domain.photo.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import mmm.emopic.app.domain.photo.Photo;
+import mmm.emopic.app.domain.photo.repository.PhotoRepositoryCustom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import static mmm.emopic.app.domain.category.QPhotoCategory.photoCategory;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PhotoRepositoryCustomImpl implements PhotoRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Photo> findByCategoryId(Long categoryId, Pageable pageable){
+        List<Photo> queryResults = queryFactory
+                .select(photoCategory.photo)
+                .from(photoCategory)
+                .where(photoCategory.category.id.eq(categoryId))
+                .fetch();
+
+        Page<Photo> pagedResults = new PageImpl<>(queryResults, pageable, queryResults.size());
+        return pagedResults;
+
+    }
+}


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약
<!-- 무엇을 구현하였는지 요약해주세요. -->
 개별사진이나 각 분류에 포함된 사진의 정보를 조회하는 기능 개발
 코드 리팩토링
 Entity에 새로운 필드 추가
# 작업 내용
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->
- Photo Entity에 signedUrl을 저장하는 필드 추가
- 폴더 변경으로 인한 import 코드 리팩토링
- 각 사진의 다운로드 경로, 분류, 감정, 일기장 등의 내용을 조회하는 API 개발
- 선택한 Category의 이미지들 정보를 조회하는 API 개발
- dto 추가

# 기타 (논의하고 싶은 부분)

close #15 #14 
