### PR TITLE
[feat] dateTime Meta데이터 받아오는 기능 추가

### DIFF
--- a/emopic/build.gradle
+++ b/emopic/build.gradle
@@ -26,11 +26,6 @@ java {
 	sourceCompatibility = '11'
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
 
 repositories {
 	mavenCentral()
@@ -74,6 +69,10 @@ dependencies {
 
 	//deepl 번역기 의존성 추가
 	implementation "com.deepl.api:deepl-java:1.3.0"
+
+	//metadata-extractor 의존성 추가
+	implementation group: 'com.drewnoakes', name: 'metadata-extractor', version: '2.6.2'
+	implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 }
 
 dependencyManagement {

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInformationResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInformationResponse.java
@@ -43,7 +43,8 @@ public class PhotoInformationResponse {
         this.categories = categoryList.stream().map(Category::getName).collect(Collectors.toList());
         List<EmotionResponse> eRList = emotionList.stream().map(EmotionResponse::new).collect(Collectors.toList());
         this.emotions = new EmotionMainSubResponse(eRList);
-        this.uploadDateTime = photo.getCreateDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        if(photo.getSnapped_at() != null)
+            this.uploadDateTime = photo.getSnapped_at().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInformationResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PhotoInformationResponse.java
@@ -10,6 +10,7 @@ import mmm.emopic.app.domain.emotion.dto.response.EmotionMainSubResponse;
 import mmm.emopic.app.domain.emotion.dto.response.EmotionResponse;
 import mmm.emopic.app.domain.photo.Photo;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,8 +44,7 @@ public class PhotoInformationResponse {
         this.categories = categoryList.stream().map(Category::getName).collect(Collectors.toList());
         List<EmotionResponse> eRList = emotionList.stream().map(EmotionResponse::new).collect(Collectors.toList());
         this.emotions = new EmotionMainSubResponse(eRList);
-        if(photo.getSnapped_at() != null)
-            this.uploadDateTime = photo.getSnapped_at().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-
+        Optional<LocalDateTime> dateTime = Optional.ofNullable(photo.getSnapped_at());
+        dateTime.ifPresent(localDateTime -> this.uploadDateTime = localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/support/CategoryInferenceResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/support/CategoryInferenceResponse.java
@@ -10,6 +10,8 @@ import java.util.List;
 public class CategoryInferenceResponse {
     private List<String> categories = new ArrayList<>();
 
+    private String dateTime;
+
     public CategoryInferenceResponse(){
 
     }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/support/PhotoInferenceWithAI.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/support/PhotoInferenceWithAI.java
@@ -30,7 +30,7 @@ public class PhotoInferenceWithAI {
 
     @Value("${ai-url}")
     private String inferenceUrl;
-    public List<String> getClassificationsByPhoto(String signedUrl) throws URISyntaxException, JsonProcessingException {
+    public CategoryInferenceResponse getClassificationsByPhoto(String signedUrl) throws URISyntaxException, JsonProcessingException {
         List<String> result= new ArrayList<>();
 
         String requestUrl = inferenceUrl+"classification";
@@ -50,9 +50,8 @@ public class PhotoInferenceWithAI {
         ObjectMapper mapper = new ObjectMapper();
 
         CategoryInferenceResponse categoryInferenceResponse = mapper.readValue(response, CategoryInferenceResponse.class);
-        result = categoryInferenceResponse.getCategories();
 
-        return result;
+        return categoryInferenceResponse;
     }
 
     public String getCaptionByPhoto(String signedUrl) throws URISyntaxException, JsonProcessingException {


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약
<!-- 무엇을 구현하였는지 요약해주세요. -->
 dateTime Meta데이터 받아오는 기능 추가
# 작업 내용
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->
- AI Inference 서버 Classifiacation 결과 반환시 이미지 파일의 meta정보를 참고하여 dateTime 결과를 같이 반환

# 기타 (논의하고 싶은 부분)
 몇몇 이미지 파일들은 meta정보를 추출할 수 없는 경우가 있음
close #이슈번호
