### PR TITLE
[refactor] : 비어있는 컬럼 내용 채우기

### DIFF
--- a/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/CategoryService.java
@@ -64,6 +64,10 @@ public class CategoryService {
             LocalDateTime strToLocalDateTime = LocalDateTime.parse(dateTime, format);
             photo.setSnapped_at(strToLocalDateTime);
         }
+        else{
+            LocalDateTime localDateTime = photo.getCreateDate();
+            photo.setSnapped_at(localDateTime);
+        }
 
         List<String> requiredTranslateResult = categoryInferenceResponse.getCategories();
         List<String> result = new ArrayList<>();

--- a/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryDetailResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/category/dto/response/CategoryDetailResponse.java
@@ -5,6 +5,7 @@ import mmm.emopic.app.domain.category.Category;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 public class CategoryDetailResponse {
@@ -19,7 +20,13 @@ public class CategoryDetailResponse {
         public CategoryDetail(Category category, Long count){
             this.categoryId = category.getId();
             this.name = category.getName();
-            this.thumbnail = category.getThumbnail();
+            Optional<String> optionThumbnail = Optional.ofNullable(category.getThumbnail());
+            if(optionThumbnail.isPresent()){
+                this.thumbnail = category.getThumbnail();
+            }
+            else{
+                this.thumbnail = "";
+            }
             this.count = count;
         }
 

--- a/emopic/src/main/java/mmm/emopic/app/domain/diary/Diary.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/diary/Diary.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class Diary extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "diary_id")
     private Long id;
 
     @Lob

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
@@ -74,6 +74,14 @@ public class PhotoService {
         String result = photoInferenceWithAI.getCaptionByPhoto(photo.getSignedUrl());
         result = deeplTranslator.translate(result);
         photo.setCaption(result);
+        Optional<Diary> optionalDiary = diaryRepository.findByPhotoId(photoId);
+        Diary diary;
+        if(optionalDiary.isEmpty()){
+            diary = Diary.builder().photo(photo).build();
+            diary = diaryRepository.save(diary);
+            diary.setContent(result);
+        }
+
         return new PhotoCaptionResponse(photo.getCaption());
 
     }


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약
<!-- 무엇을 구현하였는지 요약해주세요. -->
snapped_at, thumbnail, diary 등의 내용이 비어있으면 채워서 반환
# 작업 내용
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->
- Diary Entity pk 명을 diary_id 에서 id로 변경
- photo의 diary 내용이 비어있으면 일단 caption 내용으로 채움
- 이미지 metadata에서 datetime정보를 가져오지 못하면 snapped_at 을 create_time내용으로 채움
- thumbnail 이 비어있으면 빈 문자열 반환


# 기타 (논의하고 싶은 부분)

close #이슈번호
