### PR TITLE
update: 전체 페이지 API 페이지네이션 반환 객체 수정, signed_url 재생성하는 코드 제거 (스케줄러로 대체)…

### DIFF
--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoController.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.base.Dto.BaseResponse;
 import mmm.emopic.app.domain.photo.dto.response.*;
-import mmm.emopic.app.domain.photo.dto.request.PhotoCaptionRequest;
 import mmm.emopic.app.domain.photo.dto.request.PhotoUploadRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -66,8 +65,8 @@ public class PhotoController {
     @Operation(summary = "전체 사진 조회", responses = {
             @ApiResponse(responseCode = "200", description = "전체 사진 조회 성공", content = @Content(schema = @Schema(implementation = PhotoInformationResponse.class)))
     })
-    public ResponseEntity<BaseResponse> getPhotosInformation(@PageableDefault(page = 0, size = 10, sort="snapped_at",direction = Sort.Direction.DESC) Pageable pageable) throws IOException {
-        Page<PhotosInformationResponse> response = photoService.getPhotosInformation(pageable);
+    public ResponseEntity<BaseResponse> getPhotosInformation(@PageableDefault(page = 0, size = 10, sort="snapped_at",direction = Sort.Direction.DESC) Pageable pageable){
+        PageResponse response = photoService.getPhotosInformation(pageable);
         return ResponseEntity.ok(new BaseResponse( HttpStatus.OK.value(), "전체 사진 조회 성공", response));
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/PhotoService.java
@@ -180,14 +180,10 @@ public class PhotoService {
         return new PageImpl<>(results,pageable, photoList.getTotalElements());
     }
 
-    public Page<PhotosInformationResponse> getPhotosInformation(Pageable pageable) throws IOException {
+    public PageResponse getPhotosInformation(Pageable pageable){
         Page<Photo> photoList = photoRepositoryCustom.findAllPhotos(pageable);
         List<PhotosInformationResponse> photosInformationResponseList = new ArrayList<>();
         for(Photo photo: photoList) {
-            if (signedURLGenerator.isExpired(photo)) {
-                photo.setSignedUrl(signedURLGenerator.generateV4GetObjectSignedUrl(photo.getName()));
-                photo.setSignedUrlExpireTime(LocalDateTime.now().plusMinutes(duration));
-            }
             List<PhotoCategory> photoCategoryList = photoCategoryRepository.findByPhotoId(photo.getId());
             List<Category> categories = new ArrayList<>();
             for (PhotoCategory photoCategory : photoCategoryList) {
@@ -202,6 +198,6 @@ public class PhotoService {
             }
             photosInformationResponseList.add(new PhotosInformationResponse(photo,categories,emotions));
         }
-        return new PageImpl<>(photosInformationResponseList,pageable, photoList.getTotalElements());
+        return new PageResponse(new PageImpl<>(photosInformationResponseList,photoList.getPageable(),photoList.getTotalElements()));
     }
 }

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PageResponse.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/dto/response/PageResponse.java
@@ -1,0 +1,30 @@
+package mmm.emopic.app.domain.photo.dto.response;
+
+import lombok.Data;
+import lombok.Getter;
+import mmm.emopic.app.domain.photo.Photo;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+public class PageResponse {
+    private List<PhotosInformationResponse> content;
+
+    private long totalElements;
+    private int totalPage;
+    private boolean last;
+    private int numberOfElements;
+    private int currentPage;
+    private boolean empty;
+
+    public PageResponse(Page<PhotosInformationResponse> result) {
+        this.currentPage = result.getNumber();
+        this.totalPage = result.getTotalPages();
+        this.last = result.isLast();
+        this.content = result.getContent();
+        this.numberOfElements = result.getNumberOfElements();
+        this.totalElements = result.getTotalElements();
+        this.empty = result.isEmpty();
+    }
+}

--- a/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepositoryCustomImpl.java
+++ b/emopic/src/main/java/mmm/emopic/app/domain/photo/repository/PhotoRepositoryCustomImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import mmm.emopic.app.domain.photo.Photo;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import static mmm.emopic.app.domain.category.QPhotoCategory.photoCategory;
@@ -54,9 +56,11 @@ public class PhotoRepositoryCustomImpl implements PhotoRepositoryCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+        JPQLQuery<Photo> count = queryFactory
+                .select(photo)
+                .from(photo);
 
-        Page<Photo> pagedResults = new PageImpl<>(queryResults, pageable, queryResults.size());
-        return pagedResults;
+        return PageableExecutionUtils.getPage(queryResults,pageable,() -> count.fetchCount());
     }
     public List<Photo> findAllByExpiredTime() {
         LocalDateTime tomorrow = LocalDateTime.now().plusDays(1);


### PR DESCRIPTION

# 요약
전체 페이지에서 전체 사진 조회 API에 TotalPage, Last와 같은 엘리먼트 추가 (필요한 정보들만)

# 작업 내용
- response에 totalPage, last 객체 추가
- signed_url 재생성 코드 제거

close #50
